### PR TITLE
[1.9] add test/ to $LOAD

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -2,6 +2,8 @@
 
 $VERBOSE = true
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "test"))
+
 load 'test/test-block-parser.rb'
 load 'test/test-desclist-item.rb'
 load 'test/test-document-element.rb'

--- a/test/test-nonterminal-inline.rb
+++ b/test/test-nonterminal-inline.rb
@@ -2,7 +2,7 @@ require 'test/unit'
 
 require 'rd/inline-element'
 require 'rd/document-struct'
-require 'test/dummy'
+require 'dummy'
 
 include RD
 

--- a/test/test-output-format-visitor.rb
+++ b/test/test-output-format-visitor.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 
-require 'test/temp-dir'
+require 'temp-dir'
 
 require 'rd/output-format-visitor'
 require 'rd/tree'

--- a/test/test-rbl-file.rb
+++ b/test/test-rbl-file.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 
-require 'test/temp-dir'
+require 'temp-dir'
 
 require 'rd/rbl-file'
 require 'rd/block-element'

--- a/test/test-reference-resolver.rb
+++ b/test/test-reference-resolver.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 
-require 'test/temp-dir'
+require 'temp-dir'
 
 require 'rd/reference-resolver'
 require 'rd/tree'

--- a/test/test-reference.rb
+++ b/test/test-reference.rb
@@ -4,7 +4,7 @@ require 'rd/inline-element'
 require 'rd/document-struct'
 require 'rd/rd-struct'
 require 'rd/loose-struct'
-require 'test/dummy'
+require 'dummy'
 
 include RD
 

--- a/test/test-visitor.rb
+++ b/test/test-visitor.rb
@@ -8,7 +8,7 @@ require 'rd/methodlist'
 require 'rd/inline-element'
 require 'rd/tree'
 require 'rd/rd-struct'
-require 'test/dummy'
+require 'dummy'
 
 include RD
 


### PR DESCRIPTION
$LOAD_PATH doesn't include "." since Ruby 1.9.
