### PR TITLE
Include MethodList in imenu

### DIFF
--- a/utils/rd-mode.el
+++ b/utils/rd-mode.el
@@ -423,7 +423,7 @@
   (let ((root '(nil . nil))
         cur-alist
         (cur-level 0)
-        (pattern "^\\(=+\\)[ \t\v\f]*\\(.*?\\)[ \t\v\f]*$")
+        (pattern "^\\(=+\\|---\\)[ \t\v\f]*\\(.*?\\)[ \t\v\f]*$")
         (empty-heading "-")
         (self-heading ".")
         pos level heading alist)


### PR DESCRIPTION
I used `(setq imenu-generic-expression '((nil "^[=+-]+.+" 0)))` with old rd-mode.el.
But it does not work with current rd-mode.el.
I want to support MethodList in imenu. (Headline of `+`, `++` are unused by <https://github.com/rurema/doctree>).