### PR TITLE
Fix warnings for ruby4.0

### DIFF
--- a/lib/rd/block-element.rb
+++ b/lib/rd/block-element.rb
@@ -33,7 +33,7 @@ module RD
     end
 
     def calculate_label
-      ret = ""
+      ret = +""
       @title.each do |i|
 	ret << i.to_label
       end

--- a/lib/rd/desclist.rb
+++ b/lib/rd/desclist.rb
@@ -35,7 +35,7 @@ module RD
       end
 
       def calculate_label
-	ret = ""
+	ret = +""
 	children.each do |i|
 	  ret.concat(i.to_label)
 	end

--- a/lib/rd/element.rb
+++ b/lib/rd/element.rb
@@ -131,7 +131,7 @@ module RD
     end
 
     def indent2(str)
-      buf = ''
+      buf = +''
       str.each_line{|i| buf << "  " << i }
       buf
     end

--- a/lib/rd/inline-element.rb
+++ b/lib/rd/inline-element.rb
@@ -34,7 +34,7 @@ module RD
     end
 
     def to_label
-      ret = ""
+      ret = +""
       children.each do |i|
 	ret << i.to_label
       end
@@ -221,7 +221,7 @@ module RD
       end
 
       def extract_label(elements)
-	ret = ""
+	ret = +""
 	elements.each do |i|
 	  ret << i.to_label
 	end

--- a/lib/rd/rd2html-lib.rb
+++ b/lib/rd/rd2html-lib.rb
@@ -2,7 +2,7 @@
 = rd2html-lib.rb
 =end
 
-require "cgi"
+require "cgi/escape"
 require "rd/rdvisitor"
 require "rd/version"
 

--- a/lib/rd/rdinlineparser.ry
+++ b/lib/rd/rdinlineparser.ry
@@ -367,7 +367,7 @@ def_delegator(:@blockp, :tree)
 
 def parse(src)
   @src = StringScanner.new(src)
-  @pre = ""
+  @pre = +""
   @yydebug = true
   do_parse
 end


### PR DESCRIPTION
Currently running `$ rake test` with `ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]` causes many warnings, as shown in CI. Fix these.